### PR TITLE
Repair when items get bellow 50% durability 

### DIFF
--- a/Albion/Merlin/API/Extensions/LocalPlayerCharacter.cs
+++ b/Albion/Merlin/API/Extensions/LocalPlayerCharacter.cs
@@ -19,8 +19,13 @@ namespace Merlin.API.Direct
             return _internal.s6().eg().dv().Union(_internal.s8().eg().dv()).Any(i =>
             {
                 //EquipmentItemProxy
-                return i is as9 equipableItem ? equipableItem.ai() : false;
+                return i is as9 equipableItem ? IsTheItemQualityPoor(equipableItem) : false;
             });
+        }
+
+        public bool IsTheItemQualityPoor(as9 item)
+        {
+            return item.b6() <= 50;
         }
     }
 }

--- a/Albion/Merlin/Profiles/Gatherer/Gatherer.UI.cs
+++ b/Albion/Merlin/Profiles/Gatherer/Gatherer.UI.cs
@@ -70,7 +70,7 @@ namespace Merlin.Profiles.Gatherer
 
         private void DrawGatheringUI_Toggles()
         {
-            _allowMobHunting = GUILayout.Toggle(_allowMobHunting, "Allow hunting of living mobs (exerimental - can cause issues)");
+            _allowMobHunting = GUILayout.Toggle(_allowMobHunting, "Allow hunting of living mobs (experimental - can cause issues)");
             _skipUnrestrictedPvPZones = GUILayout.Toggle(_skipUnrestrictedPvPZones, "Skip unrestricted PvP zones while gathering");
             _skipKeeperPacks = GUILayout.Toggle(_skipKeeperPacks, "Skip keeper mobs while gathering");
             _allowSiegeCampTreasure = GUILayout.Toggle(_allowSiegeCampTreasure, "Allow usage of siege camp treasures");


### PR DESCRIPTION
Today the bot only goes to repair when the items get broken. I changed it to repair whenever they get bellow 50% durability.

Why? The higher the items the easier for the bot to kill mobs without die.